### PR TITLE
変更後ASIN機能修正 & 静的ページURL永続化機能追加

### DIFF
--- a/data/library.json
+++ b/data/library.json
@@ -1,5 +1,5 @@
 {
-  "exportDate": "2025-09-28T14:51:33.794Z",
+  "exportDate": "2025-09-28T14:57:34.321Z",
   "books": {
     "4065412382": {
       "title": "PythonではじめるMCP開発入門 (KS情報科学専門書)",
@@ -25962,17 +25962,6 @@
       "rating": 4,
       "updatedAsin": "4344033507"
     },
-    "B08XQ7LWKD": {
-      "title": "ハロー・ワールド",
-      "authors": "藤井太洋",
-      "acquiredTime": 1575676800000,
-      "readStatus": "UNKNOWN",
-      "productImage": "https://images-na.ssl-images-amazon.com/images/P/B08XQ7LWKD.01.L.jpg",
-      "source": "manual_add",
-      "addedDate": 1757137890777,
-      "memo": "",
-      "rating": 4
-    },
     "B07W3TQ4RB": {
       "title": "岩田さん: 岩田聡はこんなことを話していた。 (ほぼ日ブックス)",
       "authors": "ほぼ日刊イトイ新聞",
@@ -26463,13 +26452,14 @@
     "B07J1L1V41": {
       "title": "ハロー・ワールド",
       "authors": "藤井太洋",
-      "acquiredTime": 1575694550030,
+      "acquiredTime": 1575676800000,
       "readStatus": "READ",
-      "productImage": "",
+      "productImage": "https://images-na.ssl-images-amazon.com/images/P/B08XQ7LWKD.01.L.jpg",
       "source": "kindle_import",
       "addedDate": 1759069934295,
       "memo": "",
-      "rating": 0
+      "rating": 4,
+      "updatedAsin": "B08XQ7LWKD"
     },
     "B07K6J3T43": {
       "title": "森には森の風が吹く",
@@ -26593,7 +26583,13 @@
       ],
       "createdAt": "2025-09-06T00:53:51.680Z",
       "isPublic": true,
-      "lastUpdated": "2025-09-28T14:17:06.313Z"
+      "lastUpdated": "2025-09-28T14:17:06.313Z",
+      "staticPageInfo": {
+        "filename": "bookshelf_1757120031680.html",
+        "lastGenerated": "2025-09-28T14:51:46.145Z",
+        "ownerName": "からあげ",
+        "url": "https://karaage0703.github.io/karaage-virtual-bookshelf/bookshelf_1757120031680.html"
+      }
     },
     {
       "id": "bookshelf_1757165060966",
@@ -26686,7 +26682,13 @@
       ],
       "createdAt": "2025-09-06T13:24:20.966Z",
       "isPublic": true,
-      "lastUpdated": "2025-09-28T14:18:38.638Z"
+      "lastUpdated": "2025-09-28T14:18:38.638Z",
+      "staticPageInfo": {
+        "filename": "bookshelf_1757165060966.html",
+        "lastGenerated": "2025-09-28T14:51:53.743Z",
+        "ownerName": "からあげ",
+        "url": "https://karaage0703.github.io/karaage-virtual-bookshelf/bookshelf_1757165060966.html"
+      }
     },
     {
       "id": "bookshelf_1757120002170",
@@ -26805,7 +26807,6 @@
       "books": [
         "B00DOT529S",
         "B009IXHOJU",
-        "B08XQ7LWKD",
         "B081YHT19N",
         "B0BLV21VPF",
         "B09NBZLC7J",
@@ -26816,7 +26817,8 @@
         "B0CRTFVKT9",
         "B0CZBY35S3",
         "B01FRVHITM",
-        "B0CD79BB5C"
+        "B0CD79BB5C",
+        "B07J1L1V41"
       ],
       "createdAt": "2025-09-06T01:27:45.159Z"
     },
@@ -26863,7 +26865,8 @@
         "B0CRTFVKT9",
         "B0CZBY35S3",
         "B07CZY2M6J",
-        "B073R6HCX9"
+        "B073R6HCX9",
+        "B07J1L1V41"
       ],
       "createdAt": "2025-09-06T09:30:44.846Z"
     },
@@ -27358,7 +27361,7 @@
     ]
   },
   "stats": {
-    "totalBooks": 2407,
+    "totalBooks": 2406,
     "notesCount": 210
   },
   "version": "2.0"

--- a/data/library.json
+++ b/data/library.json
@@ -1,5 +1,5 @@
 {
-  "exportDate": "2025-09-28T12:49:30.527Z",
+  "exportDate": "2025-09-28T14:01:38.018Z",
   "books": {
     "4065412382": {
       "title": "PythonではじめるMCP開発入門 (KS情報科学専門書)",
@@ -25988,11 +25988,12 @@
       "authors": "田中修治",
       "acquiredTime": 1543190400000,
       "readStatus": "UNKNOWN",
-      "productImage": "https://images-na.ssl-images-amazon.com/images/P/B0816DC5PZ.01.L.jpg",
+      "productImage": "https://images-na.ssl-images-amazon.com/images/P/4344033507.01.L.jpg",
       "source": "manual_add",
       "addedDate": 1757123638326,
       "memo": "[「破天荒フェニックス」読んでオンデーズ行ったら思わずメガネ2本作ってしまいました](https://karaage.hatenadiary.jp/entry/2019/08/16/073000)",
-      "rating": 4
+      "rating": 4,
+      "updatedAsin": "4344033507"
     },
     "B08XQ7LWKD": {
       "title": "ハロー・ワールド",

--- a/data/library.json
+++ b/data/library.json
@@ -1,5 +1,5 @@
 {
-  "exportDate": "2025-09-28T14:01:38.018Z",
+  "exportDate": "2025-09-28T14:19:03.845Z",
   "books": {
     "4065412382": {
       "title": "PythonではじめるMCP開発入門 (KS情報科学専門書)",
@@ -26483,7 +26483,9 @@
         "B092LY4HN9",
         "B09875G3GL"
       ],
-      "createdAt": "2025-09-05T12:26:43.335Z"
+      "createdAt": "2025-09-05T12:26:43.335Z",
+      "isPublic": true,
+      "lastUpdated": "2025-09-28T14:17:02.944Z"
     },
     {
       "id": "bookshelf_1757120031680",
@@ -26572,7 +26574,9 @@
         "B078GL51L2",
         "B073R6HCX9"
       ],
-      "createdAt": "2025-09-06T00:53:51.680Z"
+      "createdAt": "2025-09-06T00:53:51.680Z",
+      "isPublic": true,
+      "lastUpdated": "2025-09-28T14:17:06.313Z"
     },
     {
       "id": "bookshelf_1757165060966",
@@ -26662,7 +26666,9 @@
         "B073R6HCX9",
         "B08FBQPF6L"
       ],
-      "createdAt": "2025-09-06T13:24:20.966Z"
+      "createdAt": "2025-09-06T13:24:20.966Z",
+      "isPublic": true,
+      "lastUpdated": "2025-09-28T14:18:38.638Z"
     },
     {
       "id": "bookshelf_1757120002170",

--- a/data/library.json
+++ b/data/library.json
@@ -1,5 +1,5 @@
 {
-  "exportDate": "2025-09-28T14:19:03.845Z",
+  "exportDate": "2025-09-28T14:51:33.794Z",
   "books": {
     "4065412382": {
       "title": "PythonではじめるMCP開発入門 (KS情報科学専門書)",
@@ -16952,17 +16952,6 @@
       "memo": "",
       "rating": 0
     },
-    "B09L8175PF": {
-      "title": "森には森の風が吹く (講談社文庫)",
-      "authors": "森博嗣",
-      "acquiredTime": 1637635653576,
-      "readStatus": "READ",
-      "productImage": "https://m.media-amazon.com/images/I/613YErMpZ7L.jpg",
-      "source": "kindle_import",
-      "addedDate": 1757091211511,
-      "memo": "",
-      "rating": 0
-    },
     "B09KTVN3CY": {
       "title": "葬送のフリーレン（６） (少年サンデーコミックス)",
       "authors": "山田鐘人, アベツカサ",
@@ -20966,17 +20955,6 @@
       "addedDate": 1757091211511,
       "memo": "",
       "rating": 0
-    },
-    "B01FRVHITM": {
-      "title": "対話篇（新潮文庫）",
-      "authors": "金城 一紀",
-      "acquiredTime": 1567472285988,
-      "readStatus": "READ",
-      "productImage": "",
-      "source": "kindle_import",
-      "addedDate": 1757091211511,
-      "memo": "",
-      "rating": 5
     },
     "B07WVZX8R7": {
       "title": "noteではじめる 新しいアウトプットの教室 楽しく続けるクリエイター生活 できるビジネスシリーズ",
@@ -25972,17 +25950,6 @@
       "memo": "",
       "rating": 0
     },
-    "B0FHPWB4KS": {
-      "title": "十戒 (講談社文庫)",
-      "authors": "夕木春央",
-      "acquiredTime": 1714953600000,
-      "readStatus": "UNKNOWN",
-      "productImage": "https://images-na.ssl-images-amazon.com/images/P/B0FHPWB4KS.01.L.jpg",
-      "source": "manual_add",
-      "addedDate": 1757122294330,
-      "memo": "",
-      "rating": 4
-    },
     "B07G32RG74": {
       "title": "破天荒フェニックス",
       "authors": "田中修治",
@@ -26017,7 +25984,7 @@
       "memo": "任天堂の元社長、岩田さんの本\n\n[おとなもこどもも、おねーさんも読んでほしい「岩田さん 岩田聡はこんなことを話していた。」](https://karaage.hatenadiary.jp/entry/2019/09/25/073000)\n\n[任天堂の宮本茂氏に学ぶ「複数の問題を一気に解決するアイデア」の重要性](https://karaage.hatenadiary.jp/entry/2025/05/05/073000)\n\n[任天堂元社長・岩田聡の仕事哲学に学ぶ。「ボトルネックを見極め、最善を尽くす」【データサイエンティスト・からあげ】](https://type.jp/et/feature/26899/)",
       "rating": 5
     },
-    "B0DBH95SGW": {
+    "B0BC8HZZZN": {
       "title": "方舟",
       "authors": "夕木春央",
       "acquiredTime": 1682899200000,
@@ -26026,7 +25993,8 @@
       "source": "manual_add",
       "addedDate": 1757160546752,
       "memo": "[久しぶりに読んだミステリー小説「方舟」で読了後ひっくり返りました](https://karaage.hatenadiary.jp/entry/2023/06/07/073000)",
-      "rating": 5
+      "rating": 5,
+      "updatedAsin": "B0DBH95SGW"
     },
     "B00DMU8S4U": {
       "title": "ぼくの地球を守って 1 (白泉社文庫)",
@@ -26097,12 +26065,12 @@
     "B009GXMFHI": {
       "title": "すべてがＦになる　THE PERFECT INSIDER Ｓ＆Ｍシリーズ (講談社文庫)",
       "authors": "森博嗣",
-      "acquiredTime": 1757167551619,
+      "acquiredTime": 1407628800000,
       "readStatus": "UNKNOWN",
       "productImage": "https://images-na.ssl-images-amazon.com/images/P/B009GXMFHI.01.L.jpg",
       "source": "manual_add",
       "addedDate": 1757167551620,
-      "memo": "[ドラマ「すべてがFになる」からの森博嗣入門](https://karaage.hatenadiary.jp/entry/2014/11/04/073000)",
+      "memo": "[ドラマ「すべてがFになる」からの森博嗣入門](https://karaage.hatenadiary.jp/entry/2014/11/04/073000)\n\n紙を購入したのは2006〜2008年だけど、電子版を購入した購入日を記入",
       "rating": 5
     },
     "4484881047": {
@@ -26127,7 +26095,7 @@
       "memo": "最近の宇宙飛行士ものの中では最高の漫画",
       "rating": 4
     },
-    "B08FBQPF6L": {
+    "B01FRVHITM": {
       "title": "対話篇",
       "authors": "金城 一紀",
       "acquiredTime": 1567468800000,
@@ -26136,7 +26104,8 @@
       "source": "manual_add",
       "addedDate": 1757336463134,
       "memo": "短編集で、どれもよいですが「花」が特によいです",
-      "rating": 5
+      "rating": 5,
+      "updatedAsin": "B08FBQPF6L"
     },
     "B06X191J7Q": {
       "title": "エスパー魔美（１） (てんとう虫コミックス)",
@@ -26146,8 +26115,8 @@
       "productImage": "https://m.media-amazon.com/images/I/51iXZSVxa8L.jpg",
       "source": "kindle_import",
       "addedDate": 1759063655445,
-      "memo": "",
-      "rating": 0
+      "memo": "最高ですね。名作「くたばれ評論家」もこの巻です",
+      "rating": 5
     },
     "B009HOCBVG": {
       "title": "並木橋通りアオバ自転車店　3巻 (ヤングキングコミックス)",
@@ -26300,8 +26269,8 @@
       "productImage": "https://m.media-amazon.com/images/I/518hStJefrL.jpg",
       "source": "kindle_import",
       "addedDate": 1759063655445,
-      "memo": "",
-      "rating": 0
+      "memo": "自転車漫画の名作",
+      "rating": 4
     },
     "B01N0Q9QEC": {
       "title": "中年スーパーマン左江内氏 (てんとう虫コミックススペシャル)",
@@ -26467,6 +26436,52 @@
       "addedDate": 1759063655445,
       "memo": "",
       "rating": 0
+    },
+    "B0CD79BB5C": {
+      "title": "十戒",
+      "authors": "夕木春央",
+      "acquiredTime": 1714953600000,
+      "readStatus": "READ",
+      "productImage": "https://images-na.ssl-images-amazon.com/images/P/B0FHPWB4KS.01.L.jpg",
+      "source": "kindle_import",
+      "addedDate": 1759069934295,
+      "memo": "",
+      "rating": 4,
+      "updatedAsin": "B0FHPWB4KS"
+    },
+    "B0C159YYCT": {
+      "title": "11話海を飼う者（前編） 螺旋じかけの海　単話版",
+      "authors": "永田礼路",
+      "acquiredTime": 1683036995927,
+      "readStatus": "UNKNOWN",
+      "productImage": "",
+      "source": "kindle_import",
+      "addedDate": 1759069934295,
+      "memo": "",
+      "rating": 0
+    },
+    "B07J1L1V41": {
+      "title": "ハロー・ワールド",
+      "authors": "藤井太洋",
+      "acquiredTime": 1575694550030,
+      "readStatus": "READ",
+      "productImage": "",
+      "source": "kindle_import",
+      "addedDate": 1759069934295,
+      "memo": "",
+      "rating": 0
+    },
+    "B07K6J3T43": {
+      "title": "森には森の風が吹く",
+      "authors": "森博嗣",
+      "acquiredTime": 1542499200000,
+      "readStatus": "READ",
+      "productImage": "https://images-na.ssl-images-amazon.com/images/P/B09L8175PF.01.L.jpg",
+      "source": "kindle_import",
+      "addedDate": 1759069934295,
+      "memo": "",
+      "rating": 0,
+      "updatedAsin": "B09L8175PF"
     }
   },
   "bookshelves": [
@@ -26572,7 +26587,9 @@
         "B07ZKG5Y2W",
         "B08FDH57JT",
         "B078GL51L2",
-        "B073R6HCX9"
+        "B073R6HCX9",
+        "B06X191J7Q",
+        "B009HOCALW"
       ],
       "createdAt": "2025-09-06T00:53:51.680Z",
       "isPublic": true,
@@ -26638,7 +26655,7 @@
         "B014GUVMLA",
         "B009KWUID8",
         "B079TMHCGZ",
-        "B0DBH95SGW",
+        "B0BC8HZZZN",
         "B00ARAH2CW",
         "B009GZIU4S",
         "B00BKR03PY",
@@ -26664,7 +26681,8 @@
         "B00CA07JLG",
         "B01NGTCARO",
         "B073R6HCX9",
-        "B08FBQPF6L"
+        "B01FRVHITM",
+        "B06X191J7Q"
       ],
       "createdAt": "2025-09-06T13:24:20.966Z",
       "isPublic": true,
@@ -26725,7 +26743,7 @@
         "B0CVL7DSBQ",
         "B07L4MWMZY",
         "B079TMHCGZ",
-        "B0DBH95SGW",
+        "B0BC8HZZZN",
         "B08FQTLBB7",
         "B00DMU8S4U",
         "B01N6HD4O4",
@@ -26787,18 +26805,18 @@
       "books": [
         "B00DOT529S",
         "B009IXHOJU",
-        "B0FHPWB4KS",
         "B08XQ7LWKD",
         "B081YHT19N",
         "B0BLV21VPF",
         "B09NBZLC7J",
         "B00J8DTRW2",
-        "B0DBH95SGW",
+        "B0BC8HZZZN",
         "B009GXMFHI",
         "B0099FLF56",
         "B0CRTFVKT9",
         "B0CZBY35S3",
-        "B08FBQPF6L"
+        "B01FRVHITM",
+        "B0CD79BB5C"
       ],
       "createdAt": "2025-09-06T01:27:45.159Z"
     },
@@ -26956,14 +26974,14 @@
         "B009GXMFHI",
         "B018FT9OLI",
         "B00J8DTRW2",
-        "B09L8175PF",
         "B075SWN1ZN",
         "B0813DY5CT",
         "B0DPFTC4B4",
         "B0CPF3NBBY",
         "B00JKZBIJ8",
         "B08NJYQJB9",
-        "B00I326W9A"
+        "B00I326W9A",
+        "B07K6J3T43"
       ],
       "createdAt": "2025-09-06T13:44:10.254Z"
     }
@@ -27340,8 +27358,8 @@
     ]
   },
   "stats": {
-    "totalBooks": 2406,
-    "notesCount": 209
+    "totalBooks": 2407,
+    "notesCount": 210
   },
   "version": "2.0"
 }

--- a/index.html
+++ b/index.html
@@ -126,8 +126,8 @@
                     <div class="library-management">
                         <h3>蔵書管理</h3>
                         <div class="management-buttons">
-                            <button id="import-kindle" class="btn btn-secondary">📥 Kindleインポート</button>
                             <button id="add-book-manually" class="btn btn-secondary">➕ 手動追加</button>
+                            <button id="import-kindle" class="btn btn-secondary">📥 Kindleインポート</button>
                             <button id="export-unified" class="btn btn-secondary">💾 データエクスポート</button>
                             <button id="clear-library" class="btn btn-danger">🗑️ 蔵書をクリア</button>
                         </div>
@@ -282,6 +282,12 @@
                 <div id="book-selection" class="book-selection" style="display: none;">
                     <h3>📚 インポートする本を選択</h3>
                     <div class="selection-controls">
+                        <div class="filter-options" style="margin-bottom: 1rem;">
+                            <label style="display: flex; align-items: center; gap: 0.5rem;">
+                                <input type="checkbox" id="hide-existing-books" checked>
+                                <span>📚 インポート済みの本を非表示にする</span>
+                            </label>
+                        </div>
                         <button id="select-all-books" class="btn btn-small">全て選択</button>
                         <button id="deselect-all-books" class="btn btn-small">全て解除</button>
                         <span class="selected-count">選択: <span id="selected-count">0</span>冊</span>

--- a/js/book-manager.js
+++ b/js/book-manager.js
@@ -37,15 +37,19 @@ class BookManager {
             const libraryData = await response.json();
             // 新しいデータ構造から古い形式に変換
             this.library = {
-                books: Object.values(libraryData.books).map(book => ({
+                books: Object.entries(libraryData.books).map(([asin, book]) => ({
                     title: book.title,
                     authors: book.authors,
                     acquiredTime: book.acquiredTime,
                     readStatus: book.readStatus,
-                    asin: Object.keys(libraryData.books).find(asin => libraryData.books[asin] === book),
+                    asin: asin,
                     productImage: book.productImage,
                     source: book.source,
-                    addedDate: book.addedDate
+                    addedDate: book.addedDate,
+                    // 追加フィールドも含める
+                    ...(book.memo && { memo: book.memo }),
+                    ...(book.rating && { rating: book.rating }),
+                    ...(book.updatedAsin && { updatedAsin: book.updatedAsin })
                 })),
                 metadata: {
                     totalBooks: libraryData.stats.totalBooks,
@@ -549,20 +553,6 @@ class BookManager {
         return this.library;
     }
 
-    /**
-     * ライブラリデータをJSONファイルとしてダウンロード
-     */
-    exportLibraryData() {
-        const dataStr = JSON.stringify(this.library, null, 2);
-        const dataBlob = new Blob([dataStr], { type: 'application/json' });
-        
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(dataBlob);
-        link.download = 'library.json';
-        link.click();
-        
-        URL.revokeObjectURL(link.href);
-    }
 
     /**
      * 統計情報を取得

--- a/js/bookshelf.js
+++ b/js/bookshelf.js
@@ -1257,6 +1257,19 @@ class VirtualBookshelf {
             const isPublic = bookshelf.isPublic || false;
             const publicBadge = isPublic ? '<span class="public-badge">📤 公開中</span>' : '';
 
+            // 静的ページ公開情報を表示
+            const staticPageInfo = bookshelf.staticPageInfo;
+            const publicUrlInfo = staticPageInfo ? `
+                <div class="public-url-info" style="margin-top: 0.5rem; padding: 0.5rem; background: #f8f9fa; border-radius: 4px; font-size: 0.9rem;">
+                    <strong>🌐 公開URL:</strong>
+                    <a href="${staticPageInfo.url}" target="_blank" style="color: #007bff; text-decoration: none;">${staticPageInfo.url}</a>
+                    <button class="btn-copy-url" onclick="navigator.clipboard.writeText('${staticPageInfo.url}'); this.textContent='✅ コピー済み'; setTimeout(() => this.textContent='📋', 2000)" style="margin-left: 0.5rem; padding: 0.2rem 0.5rem; font-size: 0.8rem; border: 1px solid #007bff; background: white; color: #007bff; border-radius: 3px; cursor: pointer;">📋</button>
+                    <div style="margin-top: 0.3rem; color: #6c757d; font-size: 0.8rem;">
+                        最終更新: ${new Date(staticPageInfo.lastGenerated).toLocaleDateString('ja-JP')}
+                    </div>
+                </div>
+            ` : '';
+
             html += `
                 <div class="bookshelf-item" data-id="${bookshelf.id}" draggable="true">
                     <div class="bookshelf-drag-handle">⋮⋮</div>
@@ -1264,6 +1277,7 @@ class VirtualBookshelf {
                         <h4>${bookshelf.emoji || '📚'} ${bookshelf.name} ${publicBadge}</h4>
                         <p>${bookshelf.description || ''}</p>
                         <span class="book-count">${bookCount}冊</span>
+                        ${isPublic ? publicUrlInfo : ''}
                     </div>
                     <div class="bookshelf-actions">
                         <button class="btn btn-secondary edit-bookshelf" data-id="${bookshelf.id}">編集</button>
@@ -2282,6 +2296,18 @@ class VirtualBookshelf {
             const isPublic = bookshelf.isPublic || false;
             const publicBadge = isPublic ? '<span class="public-badge">📤 公開中</span>' : '';
 
+            // 静的ページ公開情報を表示
+            const staticPageInfo = bookshelf.staticPageInfo;
+            const publicUrlDisplay = staticPageInfo ? `
+                <div class="public-url-preview" style="margin-top: 0.5rem; padding: 0.5rem; background: #e8f5e8; border: 1px solid #4caf50; border-radius: 4px; font-size: 0.9rem;">
+                    <div style="display: flex; align-items: center; gap: 0.5rem;">
+                        <span style="color: #4caf50; font-weight: bold;">🌐 公開中:</span>
+                        <a href="${staticPageInfo.url}" target="_blank" style="color: #4caf50; text-decoration: none; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${staticPageInfo.url}</a>
+                        <button onclick="navigator.clipboard.writeText('${staticPageInfo.url}'); this.textContent='✅'; setTimeout(() => this.textContent='📋', 2000)" style="padding: 0.2rem 0.4rem; font-size: 0.8rem; border: 1px solid #4caf50; background: white; color: #4caf50; border-radius: 3px; cursor: pointer;">📋</button>
+                    </div>
+                </div>
+            ` : '';
+
             html += `
                 <div class="bookshelf-preview ${textOnlyClass}" data-bookshelf-id="${bookshelf.id}">
                     <div class="bookshelf-preview-header">
@@ -2292,6 +2318,7 @@ class VirtualBookshelf {
                         </div>
                     </div>
                     <p>${bookshelf.description || ''}</p>
+                    ${isPublic ? publicUrlDisplay : ''}
                     <p class="book-count">${bookCount}冊</p>
                     <div class="bookshelf-preview-books">
                         ${previewBooks.map(asin => {
@@ -2547,6 +2574,16 @@ class VirtualBookshelf {
             );
 
             if (result.success) {
+                // 本棚データに公開情報を保存
+                this.currentShareBookshelf.staticPageInfo = {
+                    filename: result.filename,
+                    lastGenerated: new Date().toISOString(),
+                    ownerName: ownerNameInput.value.trim() || '本棚の所有者',
+                    // GitHub Pages URLを生成（リポジトリ名から推測）
+                    url: `https://karaage0703.github.io/karaage-virtual-bookshelf/${result.filename}`
+                };
+                this.saveUserData();
+
                 // 成功時の表示
                 resultsContent.innerHTML = `
                     <div class="success-message">
@@ -2555,10 +2592,12 @@ class VirtualBookshelf {
                             <p><strong>本棚:</strong> ${result.bookshelf.emoji} ${result.bookshelf.name}</p>
                             <p><strong>書籍数:</strong> ${result.totalBooks}冊</p>
                             <p><strong>ファイル名:</strong> ${result.filename}</p>
+                            <p><strong>公開URL:</strong> <a href="${this.currentShareBookshelf.staticPageInfo.url}" target="_blank">${this.currentShareBookshelf.staticPageInfo.url}</a></p>
                             <p><strong>注意:</strong> GitHubにpushした後にURLが有効になります</p>
                         </div>
 
                         <div class="form-actions">
+                            <button class="btn btn-primary" onclick="navigator.clipboard.writeText('${this.currentShareBookshelf.staticPageInfo.url}')">📋 URLをコピー</button>
                             <button class="btn btn-secondary" onclick="window.bookshelf.closeStaticShareModal()">閉じる</button>
                         </div>
                     </div>

--- a/js/bookshelf.js
+++ b/js/bookshelf.js
@@ -2155,7 +2155,9 @@ class VirtualBookshelf {
                         source: book.source || 'unknown',
                         addedDate: book.addedDate || Date.now(),
                         memo: this.userData.notes?.[asin]?.memo || '',
-                        rating: this.userData.notes?.[asin]?.rating || 0
+                        rating: this.userData.notes?.[asin]?.rating || 0,
+                        // updatedAsinフィールドも含める
+                        ...(book.updatedAsin && book.updatedAsin.trim() !== '' && { updatedAsin: book.updatedAsin })
                     };
                 }
             });

--- a/static/bookshelf_1757120031680.html
+++ b/static/bookshelf_1757120031680.html
@@ -1506,9 +1506,9 @@
         <footer class="footer-info">
             <h3>📤 この本棚をシェア</h3>
             <div class="share-buttons">
-                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E3%81%99%E3%81%99%E3%82%81%E3%81%AE%E6%BC%AB%E7%94%BB%20%23vbshelf%20http%3A%2F%2Flocalhost%3A8000%2Fstatic%2Fbookshelf_1757120031680.html"
+                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E3%81%99%E3%81%99%E3%82%81%E3%81%AE%E6%BC%AB%E7%94%BB%20%23vbshelf%20https%3A%2F%2Fkaraage0703.github.io%2Fkaraage-virtual-bookshelf%2Fstatic%2Fbookshelf_1757120031680.html"
                    target="_blank" class="share-btn share-twitter">🐦 Twitter</a>
-                <button onclick="copyToClipboard('おすすめの漫画 #vbshelf http://localhost:8000/static/bookshelf_1757120031680.html')" class="share-btn share-copy">📋 テキストコピー</button>
+                <button onclick="copyToClipboard('おすすめの漫画 #vbshelf https://karaage0703.github.io/karaage-virtual-bookshelf/static/bookshelf_1757120031680.html')" class="share-btn share-copy">📋 テキストコピー</button>
             </div>
 
             <p style="margin-top: 2rem; color: #666;">

--- a/static/bookshelf_1757120031680.html
+++ b/static/bookshelf_1757120031680.html
@@ -10,7 +10,7 @@
     <meta property="og:title" content="おすすめの漫画 - Virtual Bookshelf">
     <meta property="og:description" content="おすすめの漫画です。複数巻の漫画は適当に選んだ任意の一巻です">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://karaage0703.github.io/karaage-virtual-bookshelf/static/bookshelf_1757120031680.html">
+    <meta property="og:url" content="http://localhost:8000/static/bookshelf_1757120031680.html">
     <meta property="og:image" content="https://images-na.ssl-images-amazon.com/images/P/B0FG5MMSJ2.01.L.jpg">
     <meta property="og:site_name" content="Virtual Bookshelf">
 
@@ -175,7 +175,7 @@
             <h1 class="bookshelf-title">📚 おすすめの漫画</h1>
             <p class="bookshelf-description">おすすめの漫画です。複数巻の漫画は適当に選んだ任意の一巻です</p>
             <div class="bookshelf-meta">
-                <div class="bookshelf-stat">📚 80冊</div>
+                <div class="bookshelf-stat">📚 82冊</div>
                 <div class="bookshelf-stat">📅 2025年9月28日</div>
                 <div class="bookshelf-stat">👤 からあげ</div>
             </div>
@@ -1469,14 +1469,46 @@
                     </div>
                 </div>
             
+
+                <div class="static-book-item">
+                    <a href="https://www.amazon.co.jp/dp/B06X191J7Q?tag=vbookshelf-22" target="_blank" rel="noopener noreferrer">
+                        <img class="static-book-cover"
+                             src="https://images-na.ssl-images-amazon.com/images/P/B06X191J7Q.01.L.jpg"
+                             alt="エスパー魔美（１） (てんとう虫コミックス)"
+                             loading="lazy">
+                    </a>
+                    <div class="static-book-info">
+                        <div class="static-book-title">エスパー魔美（１） (てんとう虫コミックス)</div>
+                        <div class="static-book-author">藤子・Ｆ・不二雄</div>
+                        <div class="static-book-rating">⭐⭐⭐⭐⭐</div>
+                        <div class="static-book-memo">最高ですね。名作「くたばれ評論家」もこの巻です</div>
+                    </div>
+                </div>
+            
+
+                <div class="static-book-item">
+                    <a href="https://www.amazon.co.jp/dp/B009HOCALW?tag=vbookshelf-22" target="_blank" rel="noopener noreferrer">
+                        <img class="static-book-cover"
+                             src="https://images-na.ssl-images-amazon.com/images/P/B009HOCALW.01.L.jpg"
+                             alt="並木橋通りアオバ自転車店　1巻 (ヤングキングコミックス)"
+                             loading="lazy">
+                    </a>
+                    <div class="static-book-info">
+                        <div class="static-book-title">並木橋通りアオバ自転車店　1巻 (ヤングキングコミックス)</div>
+                        <div class="static-book-author">宮尾岳</div>
+                        <div class="static-book-rating">⭐⭐⭐⭐</div>
+                        <div class="static-book-memo">自転車漫画の名作</div>
+                    </div>
+                </div>
+            
         </main>
 
         <footer class="footer-info">
             <h3>📤 この本棚をシェア</h3>
             <div class="share-buttons">
-                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E3%81%99%E3%81%99%E3%82%81%E3%81%AE%E6%BC%AB%E7%94%BB%20%23vbshelf%20https%3A%2F%2Fkaraage0703.github.io%2Fkaraage-virtual-bookshelf%2Fstatic%2Fbookshelf_1757120031680.html"
+                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E3%81%99%E3%81%99%E3%82%81%E3%81%AE%E6%BC%AB%E7%94%BB%20%23vbshelf%20http%3A%2F%2Flocalhost%3A8000%2Fstatic%2Fbookshelf_1757120031680.html"
                    target="_blank" class="share-btn share-twitter">🐦 Twitter</a>
-                <button onclick="copyToClipboard('おすすめの漫画 #vbshelf https://karaage0703.github.io/karaage-virtual-bookshelf/static/bookshelf_1757120031680.html')" class="share-btn share-copy">📋 テキストコピー</button>
+                <button onclick="copyToClipboard('おすすめの漫画 #vbshelf http://localhost:8000/static/bookshelf_1757120031680.html')" class="share-btn share-copy">📋 テキストコピー</button>
             </div>
 
             <p style="margin-top: 2rem; color: #666;">

--- a/static/bookshelf_1757165060966.html
+++ b/static/bookshelf_1757165060966.html
@@ -10,7 +10,7 @@
     <meta property="og:title" content="お気に入り100冊 - Virtual Bookshelf">
     <meta property="og:description" content="お気に入りの本100冊">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://karaage0703.github.io/karaage-virtual-bookshelf/static/bookshelf_1757165060966.html">
+    <meta property="og:url" content="http://localhost:8000/static/bookshelf_1757165060966.html">
     <meta property="og:image" content="https://images-na.ssl-images-amazon.com/images/P/B01N6HD4O4.01.L.jpg">
     <meta property="og:site_name" content="Virtual Bookshelf">
 
@@ -175,7 +175,7 @@
             <h1 class="bookshelf-title">📚 お気に入り100冊</h1>
             <p class="bookshelf-description">お気に入りの本100冊</p>
             <div class="bookshelf-meta">
-                <div class="bookshelf-stat">📚 81冊</div>
+                <div class="bookshelf-stat">📚 82冊</div>
                 <div class="bookshelf-stat">📅 2025年9月28日</div>
                 <div class="bookshelf-stat">👤 からあげ</div>
             </div>
@@ -695,7 +695,9 @@
                         <div class="static-book-title">すべてがＦになる　THE PERFECT INSIDER Ｓ＆Ｍシリーズ (講談社文庫)</div>
                         <div class="static-book-author">森博嗣</div>
                         <div class="static-book-rating">⭐⭐⭐⭐⭐</div>
-                        <div class="static-book-memo"><a href="https://karaage.hatenadiary.jp/entry/2014/11/04/073000" target="_blank" rel="noopener noreferrer">ドラマ「すべてがFになる」からの森博嗣入門</a></div>
+                        <div class="static-book-memo"><a href="https://karaage.hatenadiary.jp/entry/2014/11/04/073000" target="_blank" rel="noopener noreferrer">ドラマ「すべてがFになる」からの森博嗣入門</a>
+
+紙を購入したのは2006〜2008年だけど、電子版を購入した購入日を記入</div>
                     </div>
                 </div>
             
@@ -797,9 +799,9 @@
             
 
                 <div class="static-book-item">
-                    <a href="https://www.amazon.co.jp/dp/B0816DC5PZ?tag=vbookshelf-22" target="_blank" rel="noopener noreferrer">
+                    <a href="https://www.amazon.co.jp/dp/4344033507?tag=vbookshelf-22" target="_blank" rel="noopener noreferrer">
                         <img class="static-book-cover"
-                             src="https://images-na.ssl-images-amazon.com/images/P/B0816DC5PZ.01.L.jpg"
+                             src="https://images-na.ssl-images-amazon.com/images/P/4344033507.01.L.jpg"
                              alt="破天荒フェニックス"
                              loading="lazy">
                     </a>
@@ -1485,14 +1487,30 @@
                     </div>
                 </div>
             
+
+                <div class="static-book-item">
+                    <a href="https://www.amazon.co.jp/dp/B06X191J7Q?tag=vbookshelf-22" target="_blank" rel="noopener noreferrer">
+                        <img class="static-book-cover"
+                             src="https://images-na.ssl-images-amazon.com/images/P/B06X191J7Q.01.L.jpg"
+                             alt="エスパー魔美（１） (てんとう虫コミックス)"
+                             loading="lazy">
+                    </a>
+                    <div class="static-book-info">
+                        <div class="static-book-title">エスパー魔美（１） (てんとう虫コミックス)</div>
+                        <div class="static-book-author">藤子・Ｆ・不二雄</div>
+                        <div class="static-book-rating">⭐⭐⭐⭐⭐</div>
+                        <div class="static-book-memo">最高ですね。名作「くたばれ評論家」もこの巻です</div>
+                    </div>
+                </div>
+            
         </main>
 
         <footer class="footer-info">
             <h3>📤 この本棚をシェア</h3>
             <div class="share-buttons">
-                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E6%B0%97%E3%81%AB%E5%85%A5%E3%82%8A100%E5%86%8A%20%23vbshelf%20https%3A%2F%2Fkaraage0703.github.io%2Fkaraage-virtual-bookshelf%2Fstatic%2Fbookshelf_1757165060966.html"
+                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E6%B0%97%E3%81%AB%E5%85%A5%E3%82%8A100%E5%86%8A%20%23vbshelf%20http%3A%2F%2Flocalhost%3A8000%2Fstatic%2Fbookshelf_1757165060966.html"
                    target="_blank" class="share-btn share-twitter">🐦 Twitter</a>
-                <button onclick="copyToClipboard('お気に入り100冊 #vbshelf https://karaage0703.github.io/karaage-virtual-bookshelf/static/bookshelf_1757165060966.html')" class="share-btn share-copy">📋 テキストコピー</button>
+                <button onclick="copyToClipboard('お気に入り100冊 #vbshelf http://localhost:8000/static/bookshelf_1757165060966.html')" class="share-btn share-copy">📋 テキストコピー</button>
             </div>
 
             <p style="margin-top: 2rem; color: #666;">

--- a/static/bookshelf_1757165060966.html
+++ b/static/bookshelf_1757165060966.html
@@ -1508,9 +1508,9 @@
         <footer class="footer-info">
             <h3>📤 この本棚をシェア</h3>
             <div class="share-buttons">
-                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E6%B0%97%E3%81%AB%E5%85%A5%E3%82%8A100%E5%86%8A%20%23vbshelf%20http%3A%2F%2Flocalhost%3A8000%2Fstatic%2Fbookshelf_1757165060966.html"
+                <a href="https://twitter.com/intent/tweet?text=%E3%81%8A%E6%B0%97%E3%81%AB%E5%85%A5%E3%82%8A100%E5%86%8A%20%23vbshelf%20https%3A%2F%2Fkaraage0703.github.io%2Fkaraage-virtual-bookshelf%2Fstatic%2Fbookshelf_1757165060966.html"
                    target="_blank" class="share-btn share-twitter">🐦 Twitter</a>
-                <button onclick="copyToClipboard('お気に入り100冊 #vbshelf http://localhost:8000/static/bookshelf_1757165060966.html')" class="share-btn share-copy">📋 テキストコピー</button>
+                <button onclick="copyToClipboard('お気に入り100冊 #vbshelf https://karaage0703.github.io/karaage-virtual-bookshelf/static/bookshelf_1757165060966.html')" class="share-btn share-copy">📋 テキストコピー</button>
             </div>
 
             <p style="margin-top: 2rem; color: #666;">


### PR DESCRIPTION
## 概要
- 変更後ASINフィールドのエクスポート・インポート機能を修正
- 公開本棚の静的ページURL表示機能を追加

## 実装内容

### 🔧 変更後ASINフィールドの修正
- exportUnifiedData()メソッドで変更後ASINフィールドが正しくエクスポートされるよう修正
- BookManager.initialize()メソッドでlibrary.jsonから変更後ASINを読み込み可能に修正
- 混乱を避けるため、使用されていないexportLibraryData()メソッドを削除
- エクスポート/インポートサイクルで変更後ASINデータが確実に保持されるよう改善

### 🌐 静的ページURL永続化機能
- 静的ページ情報（URL、ファイル名、生成日時）を本棚データに保存
- 本棚管理画面とホーム画面で公開URLを表示
- ワンクリックでURL をコピーできる機能を追加（視覚的フィードバック付き）
- 公開ページの最終更新日を表示
- 静的ページ生成モーダルでのURL表示を改善
- GitHub Pages URLの自動生成

## 追加機能
- 公開URL情報がlocalStorageとエクスポートデータに永続化
- 公開本棚を緑色スタイルで視覚的に識別可能
- コピーボタンでの簡単URL共有（📋 → ✅のフィードバック）
- アプリ再起動後も静的ページ情報が保持される

## テスト項目
- [x] 本編集画面での変更後ASINフィールドのテスト
- [x] エクスポート時に変更後ASINが含まれることを確認
- [x] インポート時に変更後ASINフィールドが保持されることを確認
- [x] 静的ページ生成でURL情報が保存されることをテスト
- [x] 管理画面でのURL表示を確認
- [x] URLコピー機能をテスト
- [x] セッション間でのデータ永続化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)