### PR TITLE
feat: デフォルト設定エクスポート機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,37 @@
 
 ### 5. カスタマイズ
 
+#### デフォルト設定 (data/config.json)
+
+アプリケーションのデフォルト設定を`data/config.json`で指定できます。サイドバーの「⚙️ 設定エクスポート」ボタンで現在の設定をエクスポートすることもできます。
+
+| 設定項目 | 説明 | 値 |
+|---------|------|-----|
+| `affiliateId` | Amazon AssociatesのアフィリエイトID | 文字列（例: `"your-id-22"`） |
+| `defaultView` | デフォルトの表示モード | `"covers"`: 表紙表示、`"list"`: リスト表示 |
+| `coverSize` | 表紙サイズ | `"small"`: 小、`"medium"`: 中、`"large"`: 大 |
+| `booksPerPage` | 1ページあたりの表示数 | `25`, `50`, `100`, `200`, `"all"` |
+| `enableSeriesGrouping` | シリーズグループ化 | `true`: 有効、`false`: 無効 |
+| `showImagesInOverview` | 概要での画像表示 | `true`: 表示、`false`: 非表示 |
+| `sortOrder` | 並び順 | `"custom"`: カスタム順、`"acquiredTime"`: 購入日、`"title"`: タイトル、`"authors"`: 著者 |
+| `sortDirection` | 並び方向 | `"asc"`: 昇順、`"desc"`: 降順 |
+
+**設定例:**
+```json
+{
+  "affiliateId": "your-affiliate-id",
+  "defaultView": "covers",
+  "coverSize": "medium",
+  "booksPerPage": 50,
+  "enableSeriesGrouping": true,
+  "showImagesInOverview": true,
+  "sortOrder": "acquiredTime",
+  "sortDirection": "desc"
+}
+```
+
 #### 基本設定
-- **アフィリエイトID**: `data/user_data.json`の`settings.affiliateId`を変更
+- **アフィリエイトID**: `data/config.json`の`affiliateId`を変更
 - **本棚の作成**: デフォルトの本棚を編集、新しい本棚を追加
 - **カラーテーマ**: CSS変数でカスタマイズ
 

--- a/data/config.json
+++ b/data/config.json
@@ -1,3 +1,10 @@
 {
-  "affiliateId": "vbookshelf-22"
+  "affiliateId": "vbookshelf-22",
+  "defaultView": "covers",
+  "coverSize": "medium",
+  "booksPerPage": 100,
+  "enableSeriesGrouping": true,
+  "showImagesInOverview": true,
+  "sortOrder": "custom",
+  "sortDirection": "desc"
 }

--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
                             <button id="add-book-manually" class="btn btn-secondary">➕ 手動追加</button>
                             <button id="import-kindle" class="btn btn-secondary">📥 Kindleインポート</button>
                             <button id="export-unified" class="btn btn-secondary">💾 データエクスポート</button>
+                            <button id="export-settings" class="btn btn-secondary">⚙️ 設定エクスポート</button>
                             <button id="clear-library" class="btn btn-danger">🗑️ 蔵書をクリア</button>
                         </div>
                     </div>

--- a/js/bookshelf.js
+++ b/js/bookshelf.js
@@ -167,6 +167,15 @@ class VirtualBookshelf {
             seriesGroupingCheckbox.checked = this.enableSeriesGrouping;
         }
 
+        // Load sort settings
+        if (this.userData.settings.sortOrder) {
+            this.sortOrder = this.userData.settings.sortOrder;
+            document.getElementById('sort-order').value = this.sortOrder;
+        }
+        if (this.userData.settings.sortDirection) {
+            this.sortDirection = this.userData.settings.sortDirection;
+        }
+
         this.applyFilters();
     }
 
@@ -234,6 +243,14 @@ class VirtualBookshelf {
         document.getElementById('export-unified').addEventListener('click', () => {
             this.exportUnifiedData();
         });
+
+        // Settings export button
+        const exportSettingsBtn = document.getElementById('export-settings');
+        if (exportSettingsBtn) {
+            exportSettingsBtn.addEventListener('click', () => {
+                this.exportDefaultSettings();
+            });
+        }
 
         // Bookshelf management
         const manageBookshelves = document.getElementById('manage-bookshelves');
@@ -2713,6 +2730,78 @@ class VirtualBookshelf {
         URL.revokeObjectURL(url);
         
         alert('📦 library.json をエクスポートしました！');
+    }
+
+    /**
+     * エクスポート可能な設定項目のホワイトリスト
+     */
+    static EXPORTABLE_SETTINGS = [
+        'defaultView',
+        'coverSize',
+        'booksPerPage',
+        'enableSeriesGrouping',
+        'showImagesInOverview',
+        'sortOrder',
+        'sortDirection'
+    ];
+
+    /**
+     * エクスポート用の設定オブジェクトを生成
+     * @returns {Object} フィルタリングされた設定オブジェクト
+     */
+    buildExportableSettings() {
+        if (!this.userData || !this.userData.settings) {
+            console.error('設定データが存在しません');
+            return {};
+        }
+
+        const exportSettings = {};
+        VirtualBookshelf.EXPORTABLE_SETTINGS.forEach(key => {
+            if (this.userData.settings[key] !== undefined) {
+                exportSettings[key] = this.userData.settings[key];
+            }
+        });
+
+        return exportSettings;
+    }
+
+    /**
+     * デフォルト設定をconfig.json形式でエクスポート
+     */
+    exportDefaultSettings() {
+        console.log('⚙️ 設定エクスポート開始...');
+
+        try {
+            // 設定データの存在確認
+            if (!this.userData || !this.userData.settings) {
+                throw new Error('設定データが初期化されていません');
+            }
+
+            // エクスポート用設定を生成
+            const exportSettings = this.buildExportableSettings();
+
+            console.log('📋 エクスポート設定:', exportSettings);
+
+            // JSON文字列に変換（UTF-8、2スペースインデント）
+            const jsonString = JSON.stringify(exportSettings, null, 2);
+
+            // Blobを作成してダウンロード
+            const blob = new Blob([jsonString], { type: 'application/json;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'config.json';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+
+            console.log('✅ 設定エクスポート完了');
+            alert('⚙️ config.json をエクスポートしました！\nこのファイルをdata/config.jsonとして配置すると、デフォルト設定として適用されます。');
+        } catch (error) {
+            console.error('設定エクスポートエラー:', error);
+            alert('設定のエクスポートに失敗しました: ' + error.message);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- サイドバーに「⚙️ 設定エクスポート」ボタンを追加
- 現在の表示設定をconfig.json形式でダウンロード可能に
- config.jsonに配置することでGitHub Pagesでのデフォルト設定として利用可能

## 変更内容
- **index.html**: 設定エクスポートボタンを追加
- **js/bookshelf.js**: `exportDefaultSettings()`メソッドを追加、並び順設定の読み込みに対応
- **data/config.json**: デフォルト設定値を追加
- **README.md**: 設定項目一覧テーブルを追加

## エクスポート対象設定
| 設定項目 | 説明 |
|---------|------|
| defaultView | 表示モード (covers/list) |
| coverSize | 表紙サイズ (small/medium/large) |
| booksPerPage | 1ページあたり表示数 |
| enableSeriesGrouping | シリーズグループ化 |
| showImagesInOverview | 概要での画像表示 |
| sortOrder | 並び順 |
| sortDirection | 並び方向 |

## Test plan
- [ ] サイドバーに「⚙️ 設定エクスポート」ボタンが表示される
- [ ] ボタンクリックでconfig.jsonがダウンロードされる
- [ ] ダウンロードしたJSONにaffiliateIdが含まれていない
- [ ] data/config.jsonの設定がアプリ起動時に適用される

🤖 Generated with [Claude Code](https://claude.com/claude-code)